### PR TITLE
Fix issue where sysex is never enabled when using webmidi api directly.

### DIFF
--- a/firefox/web-midi/content.js
+++ b/firefox/web-midi/content.js
@@ -1,7 +1,7 @@
 if (document instanceof HTMLDocument && !navigator.requestMIDIAccess) {
   var script = document.createElement("script");
-  script.textContent = "\n\n/// begin: [code injected by Web MIDI API browser extension]\nnavigator.requestMIDIAccess=function(){if(typeof JZZ=='undefined')window.JZZ=(" +
+  script.textContent = "\n\n/// begin: [code injected by Web MIDI API browser extension]\nnavigator.requestMIDIAccess=function(MIDIOptions){if(typeof JZZ=='undefined')window.JZZ=(" +
     _JZZ.toString() +
-    ")();navigator.requestMIDIAccess = JZZ.requestMIDIAccess;return navigator.requestMIDIAccess();}\n/// end: [code injected by Web MIDI API browser extension]\n\n";
+    ")();navigator.requestMIDIAccess = JZZ.requestMIDIAccess;return navigator.requestMIDIAccess(MIDIOptions);}\n/// end: [code injected by Web MIDI API browser extension]\n\n";
   document.documentElement.appendChild(script);
 }


### PR DESCRIPTION
This fixes an issue I noticed in testing with different browsers where any options passed to `navigator.requestMIDIAccess` are not actually passed through at teh end of the content script. Unsure if there are any side-effects here but a naive test example works now on Firefox whereas it did not before:

https://codepen.io/canuckistani-1471644214/pen/QWGdbrq?editors=1010

